### PR TITLE
add 2 options -q --quiet and -d --date

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Originally written by Derrick Childers and
 [posted to macosxhints](http://www.macosxhints.com/article.php?story=20081108132735425).
 Modifications by Guillaume Boudreau, 
 [Brian Morearty](http://github.com/BMorearty), and
-[Mark Nottingham](http://github.com/mnot).
+[Mark Nottingham](http://github.com/mnot),
+[Duoglas Du](http://github.com/duoglas).
 
 Usage
 -----
@@ -22,10 +23,14 @@ Usage
         -a, --albums    use albums instead of events
         -m, --metadata  write metadata to images
         -f, --faces     store faces as keywords (requires -m)
+	-q, --quiet	use quiet mode
+	-d, --date	stop use date prefix in folder name
 2. There is no step 2
 
 note that the -m flag is only available if extra libraries are installed; 
 see below.
+
+if you are facing encoding problems like "UnicodeEncodeError", try -q flag to stop the console output;
 
 Output
 ------
@@ -56,7 +61,7 @@ If Charlie's birthday party was on June 15th, the output folders will be:
     2009-06-15 Charlie's Birthday Party
     2009-06-20
 
-If you set useDate to False in the code, the folder names will be:
+If you set useDate to False by use -d option , the folder names will be:
 
     Jun 10, 2009
     Charlie's Birthday Party

--- a/exportiphoto.py
+++ b/exportiphoto.py
@@ -217,7 +217,7 @@ class iPhotoLibrary(object):
             self.status("\n")
 
     def copyImage(self, imageId, folderName, folderDate, 
-                  targetDir, writeMD=False, tagFaces=False):
+                  targetDir, writeMD=False, tagFaces=False, useDate=True):
         """
         Copy an image from the library to a folder in the targetDir. The
         name of the folder is based on folderName and folderDate; if
@@ -231,7 +231,7 @@ class iPhotoLibrary(object):
         except KeyError:
             raise iPhotoLibraryError, "Can't find image #%s" % imageId            
 
-        if folderDate:
+        if folderDate and useDate:
             date = '%(year)d-%(month)02d-%(day)02d' % {
                 'year': folderDate.year,
                 'month': folderDate.month,
@@ -345,14 +345,26 @@ if __name__ == '__main__':
         test=False, 
         albums=False, 
         metadata=False,
-        faces=False
+        faces=False,
+        quiet=False,
+        date=True
     )
-
+    
     option_parser.add_option("-a", "--albums",
                              action="store_true", dest="albums",
                              help="use albums instead of events"
     )
-
+     
+    option_parser.add_option("-q", "--quiet",
+                             action="store_true", dest="quiet",
+                             help="use quiet mode"
+    )
+    
+    option_parser.add_option("-d", "--date",
+                             action="store_false", dest="date",
+                             help="stop use date prefix in folder name"
+    )
+    
     if pyexiv2:
         option_parser.add_option("-m", "--metadata",
                                  action="store_true", dest="metadata",
@@ -363,19 +375,19 @@ if __name__ == '__main__':
                                  action="store_true", dest="faces",
                                  help="store faces as keywords (requires -m)"
         )
-
+    
     (options, args) = option_parser.parse_args()
     
     if len(args) != 2:
         option_parser.error(
             "Please specify an iPhoto library and a destination."
         )
-
+    
     try:
-        library = iPhotoLibrary(args[0], use_album=options.albums)
+        library = iPhotoLibrary(args[0], use_album=options.albums, quiet=options.quiet)
         def copyImage(imageId, folderName, folderDate):
             library.copyImage(imageId, folderName, folderDate, 
-                  args[1], options.metadata, options.faces)
+                  args[1], writeMD=options.metadata, tagFaces=options.faces, useDate=options.date)
     except iPhotoLibraryError, why:
         error(why[0])
     except KeyboardInterrupt:


### PR DESCRIPTION
I just add 2 options:
1. -q --quiet 
     to active the quiet mode, which is to solve the encoding problems like "UnicodeEncodeError".
2. -d --date 
     to stop adding date before the folder names. 
