### PR TITLE
Deconflict directories/filenames on export

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ Usage
 1. Run this:
         python exportiphoto.py [options] <iPhoto Library dir> <destination dir>
    Options include:
-        -a, --albums    use albums instead of events
-        -m, --metadata  write metadata to images
-        -f, --faces     store faces as keywords (requires -m)
-        -q, --quiet     use quiet mode
-        -d, --date      stop using date prefix in folder name
+        -a, --albums      use albums instead of events
+        -m, --metadata    write metadata to images
+        -f, --faces       store faces as keywords (requires -m)
+        -q, --quiet       use quiet mode
+        -d, --date        stop using date prefix in folder name
+        -x, --deconflict  deconflict export directories of same name
+
 2. There is no step 2
 
 note that the -m flag is only available if extra libraries are installed;


### PR DESCRIPTION
Using the script on a iPhoto library containing nearly 20,000 photos, I ran into several instances where photos were taken on the same date which caused separate iPhoto events to be combined into a single directory on export.  In addition, a few of the images for some reason were mapped to the same filename.  This patch corrects both issues, and ensures each iPhoto event corresponds to a unique directory and each photo to a unique filename.
